### PR TITLE
Issue 2  feat #1 회원 관리 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.7'
+    id 'org.springframework.boot' version '2.5.6' // 2.7.7
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
     id 'org.asciidoctor.convert' version '1.5.8'
 }
@@ -24,13 +24,20 @@ ext {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
+
+    // https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt
+    implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
+
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    implementation 'mysql:mysql-connector-java'
+
+    compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,6 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.security:spring-security-test'
 }
 

--- a/src/main/java/com/zerobase/musinsamonitor/config/AppConfig.java
+++ b/src/main/java/com/zerobase/musinsamonitor/config/AppConfig.java
@@ -1,0 +1,15 @@
+package com.zerobase.musinsamonitor.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/zerobase/musinsamonitor/config/AppConfig.java
+++ b/src/main/java/com/zerobase/musinsamonitor/config/AppConfig.java
@@ -1,15 +1,9 @@
 package com.zerobase.musinsamonitor.config;
 
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 public class AppConfig {
 
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
+
 }

--- a/src/main/java/com/zerobase/musinsamonitor/config/JpaAuditingConfiguration.java
+++ b/src/main/java/com/zerobase/musinsamonitor/config/JpaAuditingConfiguration.java
@@ -1,0 +1,10 @@
+package com.zerobase.musinsamonitor.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfiguration {
+
+}

--- a/src/main/java/com/zerobase/musinsamonitor/controller/AuthController.java
+++ b/src/main/java/com/zerobase/musinsamonitor/controller/AuthController.java
@@ -28,8 +28,8 @@ public class AuthController {
     /**
      * 회원가입을 위한 API
      */
-    @PostMapping("/signup")
-    public ResponseEntity<Object> signup(@RequestBody Auth.SignUp request) {
+    @PostMapping("/sign-up")
+    public ResponseEntity<Object> signUp(@RequestBody Auth.SignUp request) {
         MemberDto result = this.memberService.register(request);
         return ResponseEntity.ok(result);
     }
@@ -37,8 +37,8 @@ public class AuthController {
     /**
      * 로그인을 위한 API
      */
-    @PostMapping("/signin")
-    public ResponseEntity<Object> signin(@RequestBody Auth.SignIn request) {
+    @PostMapping("/sign-in")
+    public ResponseEntity<Object> signIn(@RequestBody Auth.SignIn request) {
         Token token = this.memberService.authenticate(request);
         return ResponseEntity.ok(token);
     }

--- a/src/main/java/com/zerobase/musinsamonitor/controller/AuthController.java
+++ b/src/main/java/com/zerobase/musinsamonitor/controller/AuthController.java
@@ -1,0 +1,45 @@
+package com.zerobase.musinsamonitor.controller;
+
+import com.zerobase.musinsamonitor.model.Auth;
+import com.zerobase.musinsamonitor.repository.entity.MemberEntity;
+import com.zerobase.musinsamonitor.security.TokenProvider;
+import com.zerobase.musinsamonitor.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@Slf4j
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final MemberService memberService;
+
+    private final TokenProvider tokenProvider;
+
+    /**
+     * 회원가입을 위한 API
+     */
+    @PostMapping("/signup")
+    public ResponseEntity<?> signup(@RequestBody Auth.SignUp request) {
+        MemberEntity result = this.memberService.register(request);
+        return ResponseEntity.ok(result);
+    }
+
+    /**
+     * 로그인을 위한 API
+     */
+    @PostMapping("/signin")
+    public ResponseEntity<?> signin(@RequestBody Auth.SignIn request) {
+        MemberEntity member = this.memberService.authenticate(request);
+        String token = this.tokenProvider.generateToken(member.getUsername(), member.getRoles());
+
+        return ResponseEntity.ok(token);
+    }
+}

--- a/src/main/java/com/zerobase/musinsamonitor/controller/AuthController.java
+++ b/src/main/java/com/zerobase/musinsamonitor/controller/AuthController.java
@@ -1,8 +1,10 @@
 package com.zerobase.musinsamonitor.controller;
 
 import com.zerobase.musinsamonitor.model.Auth;
+import com.zerobase.musinsamonitor.model.MemberDto;
+import com.zerobase.musinsamonitor.model.Token;
 import com.zerobase.musinsamonitor.repository.entity.MemberEntity;
-import com.zerobase.musinsamonitor.security.TokenProvider;
+import com.zerobase.musinsamonitor.security.jwt.TokenProvider;
 import com.zerobase.musinsamonitor.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,8 +29,8 @@ public class AuthController {
      * 회원가입을 위한 API
      */
     @PostMapping("/signup")
-    public ResponseEntity<?> signup(@RequestBody Auth.SignUp request) {
-        MemberEntity result = this.memberService.register(request);
+    public ResponseEntity<Object> signup(@RequestBody Auth.SignUp request) {
+        MemberDto result = this.memberService.register(request);
         return ResponseEntity.ok(result);
     }
 
@@ -36,10 +38,8 @@ public class AuthController {
      * 로그인을 위한 API
      */
     @PostMapping("/signin")
-    public ResponseEntity<?> signin(@RequestBody Auth.SignIn request) {
-        MemberEntity member = this.memberService.authenticate(request);
-        String token = this.tokenProvider.generateToken(member.getUsername(), member.getRoles());
-
+    public ResponseEntity<Object> signin(@RequestBody Auth.SignIn request) {
+        Token token = this.memberService.authenticate(request);
         return ResponseEntity.ok(token);
     }
 }

--- a/src/main/java/com/zerobase/musinsamonitor/exception/CustomException.java
+++ b/src/main/java/com/zerobase/musinsamonitor/exception/CustomException.java
@@ -1,0 +1,17 @@
+package com.zerobase.musinsamonitor.exception;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CustomException extends RuntimeException{
+    private ErrorCode errorCode;
+}

--- a/src/main/java/com/zerobase/musinsamonitor/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/musinsamonitor/exception/ErrorCode.java
@@ -1,0 +1,31 @@
+package com.zerobase.musinsamonitor.exception;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    /* 400 BAD_REQUEST : 잘못된 요청 */
+    USER_NOT_FOUND(BAD_REQUEST, "사용자가 없습니다."),
+    EMAIL_ALREADY_USED(BAD_REQUEST,"이미 사용 중인 이메일입니다."),
+    EMAIL_NOT_FOUND(BAD_REQUEST, "존재하지 않는 Email 입니다."),
+    PASSWORD_DO_NOT_MATCH(BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    /* 401 UNAUTHORIZED : 인증되지 않은 사용자 */
+
+    /* 404 NOT_FOUND : Resource 를 찾을 수 없음 */
+
+    /* 409 CONFLICT : Resource 의 현재 상태와 충돌. 보통 중복된 데이터 존재 */
+    DUPLICATE_RESOURCE(CONFLICT, "데이터가 이미 존재합니다"),
+
+    /* 500 Internal Server Error : 서버가 처리 방법을 모르는 상황이 발생. 서버는 아직 처리 방법을 알 수 없음.*/
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String description;
+
+}

--- a/src/main/java/com/zerobase/musinsamonitor/exception/ErrorResponse.java
+++ b/src/main/java/com/zerobase/musinsamonitor/exception/ErrorResponse.java
@@ -1,0 +1,31 @@
+package com.zerobase.musinsamonitor.exception;
+
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+@Builder
+public class ErrorResponse {
+
+    private final LocalDateTime timestamp = LocalDateTime.now();
+    private final int status;
+    private final String error;
+    private final String code;
+    private final String message;
+
+    public static ResponseEntity<ErrorResponse> toResponseEntity(ErrorCode errorCode) {
+        return ResponseEntity
+            .status(errorCode.getHttpStatus())
+            .body(ErrorResponse.builder()
+                .status(errorCode.getHttpStatus().value())
+                .error(errorCode.getHttpStatus().name())
+                .code(errorCode.name())
+                .message(errorCode.getDescription())
+                .build()
+            );
+    }
+
+}

--- a/src/main/java/com/zerobase/musinsamonitor/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/zerobase/musinsamonitor/exception/GlobalExceptionHandler.java
@@ -1,0 +1,35 @@
+package com.zerobase.musinsamonitor.exception;
+
+import static com.zerobase.musinsamonitor.exception.ErrorCode.DUPLICATE_RESOURCE;
+
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(value = {ConstraintViolationException.class, DataIntegrityViolationException.class})
+    protected ResponseEntity<ErrorResponse> handleDataException() {
+        log.error("handleDataException throw Exception : {}", DUPLICATE_RESOURCE);
+        return ErrorResponse.toResponseEntity(DUPLICATE_RESOURCE);
+    }
+
+    @ExceptionHandler(value = CustomException.class)
+    protected ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        log.error("handleCustomException throw CustomException : {}", e.getErrorCode());
+        return ErrorResponse.toResponseEntity(e.getErrorCode());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Exception is occurred.", e);
+
+        return ErrorResponse.toResponseEntity(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/zerobase/musinsamonitor/model/Auth.java
+++ b/src/main/java/com/zerobase/musinsamonitor/model/Auth.java
@@ -1,0 +1,36 @@
+package com.zerobase.musinsamonitor.model;
+
+import com.zerobase.musinsamonitor.repository.entity.MemberEntity;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Data;
+
+public class Auth {
+
+    @Data
+    public static class SignIn {
+
+        private String email;
+        private String password;
+    }
+
+    @Data
+    public static class SignUp {
+
+        private String email;
+        private String username;
+        private String password;
+        private List<String> roles;
+
+        public MemberEntity toEntity() {
+            return MemberEntity.builder()
+                .email(this.email)
+                .username(this.username)
+                .password(this.password)
+                .roles(this.roles)
+                .createAt(LocalDateTime.now())
+                .build();
+        }
+    }
+
+}

--- a/src/main/java/com/zerobase/musinsamonitor/model/Auth.java
+++ b/src/main/java/com/zerobase/musinsamonitor/model/Auth.java
@@ -1,36 +1,46 @@
 package com.zerobase.musinsamonitor.model;
 
+import com.sun.istack.NotNull;
 import com.zerobase.musinsamonitor.repository.entity.MemberEntity;
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.stereotype.Service;
 
 public class Auth {
 
-    @Data
+    @Getter
+    @Setter
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
     public static class SignIn {
 
+        @NotNull
         private String email;
+
+        @NotNull
         private String password;
     }
 
-    @Data
+    @Getter
+    @Setter
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
     public static class SignUp {
-
         private String email;
         private String username;
         private String password;
         private List<String> roles;
-
-        public MemberEntity toEntity() {
-            return MemberEntity.builder()
-                .email(this.email)
-                .username(this.username)
-                .password(this.password)
-                .roles(this.roles)
-                .createAt(LocalDateTime.now())
-                .build();
-        }
     }
 
 }

--- a/src/main/java/com/zerobase/musinsamonitor/model/MemberDto.java
+++ b/src/main/java/com/zerobase/musinsamonitor/model/MemberDto.java
@@ -1,0 +1,34 @@
+package com.zerobase.musinsamonitor.model;
+
+import com.zerobase.musinsamonitor.repository.entity.MemberEntity;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberDto {
+    private String email;
+    private String username;
+    private List<String> roles;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+
+    public static MemberDto fromEntity(MemberEntity memberEntity){
+        return MemberDto.builder()
+            .email(memberEntity.getEmail())
+            .username(memberEntity.getUsername())
+            .createdAt(memberEntity.getCreatedAt())
+            .updatedAt(memberEntity.getUpdatedAt())
+            .roles(memberEntity.getRoles())
+            .build();
+    }
+}

--- a/src/main/java/com/zerobase/musinsamonitor/model/Token.java
+++ b/src/main/java/com/zerobase/musinsamonitor/model/Token.java
@@ -1,0 +1,14 @@
+package com.zerobase.musinsamonitor.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class Token {
+    private String token;
+}

--- a/src/main/java/com/zerobase/musinsamonitor/model/constants/Authority.java
+++ b/src/main/java/com/zerobase/musinsamonitor/model/constants/Authority.java
@@ -3,6 +3,7 @@ package com.zerobase.musinsamonitor.model.constants;
 public enum Authority {
 
     ROLE_ADMIN,
-    ROLE_USER
+    ROLE_USER,
+    ROLE_NOT_PERMITTED
 
 }

--- a/src/main/java/com/zerobase/musinsamonitor/model/constants/Authority.java
+++ b/src/main/java/com/zerobase/musinsamonitor/model/constants/Authority.java
@@ -1,0 +1,8 @@
+package com.zerobase.musinsamonitor.model.constants;
+
+public enum Authority {
+
+    ROLE_ADMIN,
+    ROLE_USER
+
+}

--- a/src/main/java/com/zerobase/musinsamonitor/repository/MemberRepository.java
+++ b/src/main/java/com/zerobase/musinsamonitor/repository/MemberRepository.java
@@ -1,0 +1,16 @@
+package com.zerobase.musinsamonitor.repository;
+
+import com.zerobase.musinsamonitor.repository.entity.MemberEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
+    Optional<MemberEntity> findByUsername(String username);
+    Optional<MemberEntity> findByEmail(String email);
+
+    boolean existsByUsername(String username);
+    boolean existsByEmail(String email);
+
+}

--- a/src/main/java/com/zerobase/musinsamonitor/repository/MemberRepository.java
+++ b/src/main/java/com/zerobase/musinsamonitor/repository/MemberRepository.java
@@ -7,10 +7,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
-    Optional<MemberEntity> findByUsername(String username);
     Optional<MemberEntity> findByEmail(String email);
-
-    boolean existsByUsername(String username);
     boolean existsByEmail(String email);
-
 }

--- a/src/main/java/com/zerobase/musinsamonitor/repository/entity/BaseEntity.java
+++ b/src/main/java/com/zerobase/musinsamonitor/repository/entity/BaseEntity.java
@@ -1,0 +1,35 @@
+package com.zerobase.musinsamonitor.repository.entity;
+
+import java.time.LocalDateTime;
+import javax.persistence.EntityListeners;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(builderMethodName = "doseNotUseThisBuilder")
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/zerobase/musinsamonitor/repository/entity/MemberEntity.java
+++ b/src/main/java/com/zerobase/musinsamonitor/repository/entity/MemberEntity.java
@@ -1,0 +1,75 @@
+package com.zerobase.musinsamonitor.repository.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Builder
+@Entity(name = "MEMBER")
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberEntity implements UserDetails {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+
+    private String email;
+
+    @JsonIgnore
+    private String password;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    private List<String> roles;
+
+    private LocalDateTime createAt;
+    private LocalDateTime updateAt;
+
+    @Override
+    @JsonIgnore
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return roles.stream()
+            .map(SimpleGrantedAuthority::new) // Spring Security에서 제공해주는 ROLE 관련 기능을 사용하기 위해 mapping
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return false;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+}

--- a/src/main/java/com/zerobase/musinsamonitor/repository/entity/MemberEntity.java
+++ b/src/main/java/com/zerobase/musinsamonitor/repository/entity/MemberEntity.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -16,6 +17,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -26,15 +28,11 @@ import org.springframework.security.core.userdetails.UserDetails;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
-public class MemberEntity implements UserDetails {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+@EntityListeners(AuditingEntityListener.class)
+public class MemberEntity extends BaseEntity implements UserDetails {
+    private String email;
 
     private String username;
-
-    private String email;
 
     @JsonIgnore
     private String password;
@@ -42,8 +40,13 @@ public class MemberEntity implements UserDetails {
     @ElementCollection(fetch = FetchType.EAGER)
     private List<String> roles;
 
-    private LocalDateTime createAt;
-    private LocalDateTime updateAt;
+    // 이메일 인증 여부
+    private boolean emailAuthYn;
+    private LocalDateTime emailAuthDt;
+
+    // 메일을 통해서 인증키를 보내주면 해당 인증키가 맞는지를 검사하기 위해 임의의 값을 저장하여 값 비교
+    // 회원가입할 때 key를 만들어서 이메일로 보내주고 보내준 이메일 링크를 통해 인증 절차 진행
+    private String emailAuthKey;
 
     @Override
     @JsonIgnore

--- a/src/main/java/com/zerobase/musinsamonitor/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zerobase/musinsamonitor/security/JwtAuthenticationFilter.java
@@ -1,0 +1,63 @@
+package com.zerobase.musinsamonitor.security;
+
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    public static final String TOKEN_HEADER = "Authorization";
+    public static final String TOKEN_PREFIX = "Bearer ";
+
+    private final TokenProvider tokenProvider;
+
+    // OncePerRequestFilter 에 의해 요청이 들어올 때마다
+    // Filter가 Control이 실행되기 전에 먼저 실행되면서
+    // 요청의 header에 token이 있는지 확인하고 token이 유효하다면 인증 정보를 context에 담는다.
+    // 만약 유효하지 않다면 다음 filter를 거치면서 실행
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain
+    ) throws ServletException, IOException
+    {
+        String token = this.resolveTokenFromRequest(request);
+
+        if(StringUtils.hasText(token) && this.tokenProvider.validateToken(token)){
+            // 토큰 유효성 검증
+            Authentication auth = this.tokenProvider.getAuthorization(token);
+
+            // Security Context 에 인증 정보 넣기
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * request에 있는 header로부터 token 얻기
+     */
+    private String resolveTokenFromRequest(HttpServletRequest request){
+        String token = request.getHeader(TOKEN_HEADER);
+
+        if(!ObjectUtils.isEmpty(token) && token.startsWith(TOKEN_PREFIX)){
+            return token.substring(TOKEN_PREFIX.length());
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/zerobase/musinsamonitor/security/SecurityConfiguration.java
+++ b/src/main/java/com/zerobase/musinsamonitor/security/SecurityConfiguration.java
@@ -1,0 +1,58 @@
+package com.zerobase.musinsamonitor.security;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Slf4j
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+@RequiredArgsConstructor
+public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+
+        http
+            .httpBasic().disable()
+            .csrf().disable()
+            .sessionManagement()
+            .sessionCreationPolicy(SessionCreationPolicy.STATELESS) // jwt 토큰으로 구현했기 때문에 상태 정보 저장X
+            .and()
+            .authorizeRequests()
+            .antMatchers("/**/signup", "/**/signin").permitAll()
+            .and()
+            .addFilterBefore(this.jwtAuthenticationFilter,
+                UsernamePasswordAuthenticationFilter.class); // 필터 순서 정의
+
+        super.configure(http);
+    }
+
+    @Override
+    public void configure(WebSecurity web) throws Exception {
+//        web.ignoring()
+//            .antMatchers("/h2-console/**");
+
+        super.configure(web);
+    }
+
+    // spring boot 2.x
+    @Bean
+    @Override
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
+    }
+}
+

--- a/src/main/java/com/zerobase/musinsamonitor/security/SecurityConfiguration.java
+++ b/src/main/java/com/zerobase/musinsamonitor/security/SecurityConfiguration.java
@@ -1,5 +1,6 @@
 package com.zerobase.musinsamonitor.security;
 
+import com.zerobase.musinsamonitor.security.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
@@ -11,6 +12,8 @@ import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Slf4j
@@ -21,6 +24,11 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {

--- a/src/main/java/com/zerobase/musinsamonitor/security/TokenProvider.java
+++ b/src/main/java/com/zerobase/musinsamonitor/security/TokenProvider.java
@@ -1,0 +1,93 @@
+package com.zerobase.musinsamonitor.security;
+
+import com.zerobase.musinsamonitor.service.MemberService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.util.Date;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.tomcat.util.http.parser.Authorization;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TokenProvider {
+
+    private static final long TOKEN_EXPIRE_TIME = 1000 * 60 * 60; // 1000ms * 60s * 60m : 1 hour
+    private static final String KEY_ROLES = "roles";
+
+    private final MemberService memberService;
+
+    @Value("${spring.jwt.secret}")
+    private String secretKey;
+
+    /**
+     * 토큰 생성(발급)
+     *
+     * @param username
+     * @param roles
+     * @return
+     */
+    public String generateToken(String username, List<String> roles) {
+        Claims claims = Jwts.claims().setSubject(username);
+        claims.put(KEY_ROLES, roles);
+
+        // 토큰 생성 시간
+        Date now = new Date();
+
+        // 토큰 만료 시간 ( 생성 시간부터 1시간 )
+        Date expireDate = new Date(now.getTime() + TOKEN_EXPIRE_TIME);
+
+        return Jwts.builder()
+            .setClaims(claims)
+            .setIssuedAt(now) // 토큰 생성 시간
+            .setExpiration(expireDate) // 토큰 만료 시간
+            .signWith(SignatureAlgorithm.HS512, this.secretKey) // 사용할 암호화 알고리즘, 비밀키
+            .compact();
+    }
+
+    /**
+     * jwt 로부터 인증 정보 가져오기
+     */
+    public Authentication getAuthorization(String jwt){
+        UserDetails userDetails = this.memberService.loadUserByUsername(this.getEmail(jwt));
+        // 사용자 정보, 사용자 권한 정보를 포함한 token
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    public String getEmail(String token){
+        return this.parseClaims(token).getSubject();
+    }
+
+    public boolean validateToken(String token){
+        if(!StringUtils.hasText(token)) return false;
+
+        Claims claims = this.parseClaims(token);
+
+        // 검사하려는 토큰이 갖고 있는 만료 시간이 현재 시간 이전인지 아닌지로 만료 여부 체크
+        return !claims.getExpiration().before(new Date());
+    }
+
+    /**
+     * 토큰 디코딩
+     * @param token
+     * @return
+     */
+    private Claims parseClaims(String token) {
+        log.info("get All Claims token = {}", token);
+        try {
+            return Jwts.parser().setSigningKey(this.secretKey).parseClaimsJws(token).getBody();
+        }catch (ExpiredJwtException e){
+            return e.getClaims();
+        }
+    }
+}

--- a/src/main/java/com/zerobase/musinsamonitor/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zerobase/musinsamonitor/security/jwt/JwtAuthenticationFilter.java
@@ -32,7 +32,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String token = this.resolveTokenFromRequest(request);
 
-        if (StringUtils.hasText(token) && this.tokenProvider.validateToken(token)) {
+        if (StringUtils.hasText(token) && this.tokenProvider.isValidationToken(token)) {
             // 토큰 유효성 검증
             Authentication auth = this.tokenProvider.getAuthorization(token);
 

--- a/src/main/java/com/zerobase/musinsamonitor/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zerobase/musinsamonitor/security/jwt/JwtAuthenticationFilter.java
@@ -1,4 +1,4 @@
-package com.zerobase.musinsamonitor.security;
+package com.zerobase.musinsamonitor.security.jwt;
 
 import java.io.IOException;
 import javax.servlet.FilterChain;
@@ -29,15 +29,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     // 요청의 header에 token이 있는지 확인하고 token이 유효하다면 인증 정보를 context에 담는다.
     // 만약 유효하지 않다면 다음 filter를 거치면서 실행
     @Override
-    protected void doFilterInternal(
-        HttpServletRequest request,
-        HttpServletResponse response,
-        FilterChain filterChain
-    ) throws ServletException, IOException
-    {
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String token = this.resolveTokenFromRequest(request);
 
-        if(StringUtils.hasText(token) && this.tokenProvider.validateToken(token)){
+        if (StringUtils.hasText(token) && this.tokenProvider.validateToken(token)) {
             // 토큰 유효성 검증
             Authentication auth = this.tokenProvider.getAuthorization(token);
 
@@ -51,10 +46,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     /**
      * request에 있는 header로부터 token 얻기
      */
-    private String resolveTokenFromRequest(HttpServletRequest request){
+    private String resolveTokenFromRequest(HttpServletRequest request) {
         String token = request.getHeader(TOKEN_HEADER);
 
-        if(!ObjectUtils.isEmpty(token) && token.startsWith(TOKEN_PREFIX)){
+        if (!ObjectUtils.isEmpty(token) && token.startsWith(TOKEN_PREFIX)) {
             return token.substring(TOKEN_PREFIX.length());
         }
 

--- a/src/main/java/com/zerobase/musinsamonitor/security/jwt/TokenProvider.java
+++ b/src/main/java/com/zerobase/musinsamonitor/security/jwt/TokenProvider.java
@@ -72,7 +72,7 @@ public class TokenProvider {
         return this.parseClaims(token).getSubject();
     }
 
-    public boolean validateToken(String token){
+    public boolean isValidationToken(String token){
         if(!StringUtils.hasText(token)) return false;
 
         Claims claims = this.parseClaims(token);

--- a/src/main/java/com/zerobase/musinsamonitor/service/MemberDetailService.java
+++ b/src/main/java/com/zerobase/musinsamonitor/service/MemberDetailService.java
@@ -1,0 +1,22 @@
+package com.zerobase.musinsamonitor.service;
+
+import com.zerobase.musinsamonitor.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberDetailService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        // findByUsername는 Optional 값을 return하지만 orElseThrow을 사용했으므로 Optional이 벗겨진 MemberEntity반환
+        return this.memberRepository.findByEmail(email)
+            .orElseThrow(() -> new UsernameNotFoundException("couldn't find user -> " + email));
+    }
+}

--- a/src/main/java/com/zerobase/musinsamonitor/service/MemberDetailService.java
+++ b/src/main/java/com/zerobase/musinsamonitor/service/MemberDetailService.java
@@ -1,5 +1,8 @@
 package com.zerobase.musinsamonitor.service;
 
+import static com.zerobase.musinsamonitor.exception.ErrorCode.EMAIL_NOT_FOUND;
+
+import com.zerobase.musinsamonitor.exception.CustomException;
 import com.zerobase.musinsamonitor.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -15,8 +18,8 @@ public class MemberDetailService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        // findByUsername는 Optional 값을 return하지만 orElseThrow을 사용했으므로 Optional이 벗겨진 MemberEntity반환
         return this.memberRepository.findByEmail(email)
-            .orElseThrow(() -> new UsernameNotFoundException("couldn't find user -> " + email));
+//            .orElseThrow(() -> new UsernameNotFoundException("couldn't find user -> " + email));
+            .orElseThrow(() -> new CustomException(EMAIL_NOT_FOUND));
     }
 }

--- a/src/main/java/com/zerobase/musinsamonitor/service/MemberService.java
+++ b/src/main/java/com/zerobase/musinsamonitor/service/MemberService.java
@@ -1,12 +1,16 @@
 package com.zerobase.musinsamonitor.service;
 
+import static com.zerobase.musinsamonitor.exception.ErrorCode.EMAIL_ALREADY_USED;
+import static com.zerobase.musinsamonitor.exception.ErrorCode.EMAIL_NOT_FOUND;
+import static com.zerobase.musinsamonitor.exception.ErrorCode.PASSWORD_DO_NOT_MATCH;
+
+import com.zerobase.musinsamonitor.exception.CustomException;
 import com.zerobase.musinsamonitor.model.Auth;
 import com.zerobase.musinsamonitor.model.MemberDto;
 import com.zerobase.musinsamonitor.model.Token;
 import com.zerobase.musinsamonitor.repository.MemberRepository;
 import com.zerobase.musinsamonitor.repository.entity.MemberEntity;
 import com.zerobase.musinsamonitor.security.jwt.TokenProvider;
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -26,10 +30,8 @@ public class MemberService {
         boolean exists = this.memberRepository.existsByEmail(request.getEmail());
 
         if (exists) {
-            throw new RuntimeException("이미 사용 중인 이메일입니다.");
+            throw new CustomException(EMAIL_ALREADY_USED);
         }
-
-//        request.setPassword(this.passwordEncoder.encode(request.getPassword()));
 
         String encodedPassword = this.passwordEncoder.encode(request.getPassword());
 
@@ -46,10 +48,10 @@ public class MemberService {
     // password 인증
     public Token authenticate(Auth.SignIn request) {
         MemberEntity user = this.memberRepository.findByEmail(request.getEmail())
-            .orElseThrow(() -> new RuntimeException("존재하지 않는 Email 입니다."));
+            .orElseThrow(() -> new CustomException(EMAIL_NOT_FOUND));
 
         if (!this.passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-            throw new RuntimeException("비밀번호가 일치하지 않습니다.");
+            throw new CustomException(PASSWORD_DO_NOT_MATCH);
         }
 
         return this.tokenProvider.generateToken(user.getUsername(), user.getRoles());

--- a/src/main/java/com/zerobase/musinsamonitor/service/MemberService.java
+++ b/src/main/java/com/zerobase/musinsamonitor/service/MemberService.java
@@ -1,0 +1,52 @@
+package com.zerobase.musinsamonitor.service;
+
+import com.zerobase.musinsamonitor.model.Auth;
+import com.zerobase.musinsamonitor.repository.entity.MemberEntity;
+import com.zerobase.musinsamonitor.repository.MemberRepository;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@AllArgsConstructor
+public class MemberService implements UserDetailsService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        // findByUsername는 Optional 값을 return하지만 orElseThrow을 사용했으므로 Optional이 벗겨진 MemberEntity반환
+        return this.memberRepository.findByEmail(email)
+            .orElseThrow(() -> new UsernameNotFoundException("couldn't find user -> " + email));
+    }
+
+    public MemberEntity register(Auth.SignUp member) {
+//        boolean exists = this.memberRepository.existsByUsername(member.getUsername());
+        boolean exists = this.memberRepository.existsByEmail(member.getEmail());
+        if (exists) {
+            throw new RuntimeException("이미 사용 중인 이메일입니다.");
+        }
+
+        member.setPassword(this.passwordEncoder.encode(member.getPassword()));
+
+        return this.memberRepository.save(member.toEntity());
+    }
+
+    // password 인증
+    public MemberEntity authenticate(Auth.SignIn member) {
+        MemberEntity user = this.memberRepository.findByEmail(member.getEmail())
+            .orElseThrow(() -> new RuntimeException("존재하지 않는 Email 입니다."));
+
+        if (!this.passwordEncoder.matches(member.getPassword(), user.getPassword())) {
+            throw new RuntimeException("비밀번호가 일치하지 않습니다.");
+        }
+
+        return user;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,41 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/musinsa_monitor
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: won9975744
+
+  jpa:
+    generate-ddl: true
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+
+  jwt:
+    secret: ZGF5b25lLXNwcmluZy1ib290LW11c2luc2EtbW9uaXRvci1wcm9qZWN0LWp3dC1zZWNyZXQK
+
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: seyoung574458@gmail.com
+    password: ozqghngdsrsxbycz
+    properties:
+      mail:
+        smtp:
+          ssl:
+            protocols: TLSv1.2
+          starttls:
+            enable: true
+
+jasypt:
+  encryptor:
+    bean: jasyptStringEncryptor
+
+
+
+
+
+
+
+
+

--- a/src/test/java/com/zerobase/musinsamonitor/MusinsaMonitorApplicationTests.java
+++ b/src/test/java/com/zerobase/musinsamonitor/MusinsaMonitorApplicationTests.java
@@ -1,13 +1,11 @@
 package com.zerobase.musinsamonitor;
 
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class MusinsaMonitorApplicationTests {
 
-    @Test
-    void contextLoads() {
-    }
 
 }

--- a/src/test/java/com/zerobase/musinsamonitor/service/MemberServiceTest.java
+++ b/src/test/java/com/zerobase/musinsamonitor/service/MemberServiceTest.java
@@ -1,0 +1,149 @@
+package com.zerobase.musinsamonitor.service;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.zerobase.musinsamonitor.model.Auth;
+import com.zerobase.musinsamonitor.model.Auth.SignIn;
+import com.zerobase.musinsamonitor.model.Auth.SignUp;
+import com.zerobase.musinsamonitor.model.MemberDto;
+import com.zerobase.musinsamonitor.model.Token;
+import com.zerobase.musinsamonitor.repository.MemberRepository;
+import com.zerobase.musinsamonitor.repository.entity.MemberEntity;
+import com.zerobase.musinsamonitor.security.jwt.TokenProvider;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Spy
+    private BCryptPasswordEncoder passwordEncoder;
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    @Test
+    void signup_success() {
+        //given
+        List<String> roles = new ArrayList<>();
+        roles.add("ROLE_USER");
+
+        Auth.SignUp request = Auth.SignUp.builder()
+            .email("test1@naver.com")
+            .username("test")
+            .password("123")
+            .roles(roles)
+            .build();
+
+        given(memberRepository.existsByEmail(anyString()))
+            .willReturn(false);
+
+        given(memberRepository.save(any()))
+            .willReturn(MemberEntity.builder()
+                .email("test1@naver.com")
+                .username("test")
+                .build());
+
+        // save에서 저장되는 실제 MemberEntity는 captor 안으로 들어감.
+        ArgumentCaptor<MemberEntity> captor = ArgumentCaptor.forClass(MemberEntity.class);
+
+        //when
+        MemberDto register = memberService.register(request);
+        System.out.println(register);
+
+        //then
+        verify(memberRepository, times(1)).save(captor.capture());
+    }
+
+    // https://cantcoding.tistory.com/69
+
+    @Test
+    void signup_EmailAlreadyExists() {
+        //given
+        List<String> roles = new ArrayList<>();
+        roles.add("ROLE_USER");
+
+        Auth.SignUp request = Auth.SignUp.builder()
+            .email("seyoung5744@naver.com")
+            .username("won")
+            .password("123")
+            .roles(roles)
+            .build();
+
+        given(memberRepository.existsByEmail(anyString()))
+            .willReturn(true);
+
+        // when
+        RuntimeException exception = assertThrows(RuntimeException.class,
+            () -> memberService.register(request));
+
+        System.out.println(exception.getMessage());
+        //then
+        assertEquals("이미 사용 중인 이메일입니다.", exception.getMessage());
+    }
+
+    @Test
+    void login_success() {
+        //given
+        String encodedPassword = passwordEncoder.encode("1234");
+
+        MemberEntity entity = MemberEntity.builder()
+            .username("won")
+            .email("test1@naver.com")
+            .password(encodedPassword)
+            .roles(Collections.singletonList("ROLE_USER"))
+            .build();
+
+        SignIn request = SignIn.builder()
+            .email("test1@naver.com")
+            .password("1234")
+            .build();
+
+        Token token = new Token("test");
+
+
+        given(memberRepository.findByEmail(anyString()))
+            .willReturn(Optional.of(entity));
+
+        given(tokenProvider.generateToken(anyString(), anyList()))
+            .willReturn(token);
+
+        // when
+        Token authenticate = memberService.authenticate(request);
+
+        // then
+        assertEquals(token, authenticate);
+    }
+}


### PR DESCRIPTION
변경사항
----
- #2 


AS-IS
-----
#### 회원가입
- 이메일, 이름, 비밀번호, ROLE을 통해 회원 가입.
- 이메일 중복이면 가입 불가.

#### 로그인 
- 이메일과 비밀번호를 통해 로그인.
- 로그인 성공 지JWT access Token 발행

#### 예외 처리 표준화
- 공통된 에러 응답을 위한 Global Exceprion을 구현.
- 에러 발생 시간, HTTP 상태 및 에러 코드, 설명을 응답.
- 에러 예시)

![에러 예시](https://user-images.githubusercontent.com/53173850/210754458-346179c8-a190-4950-9121-7cb540e52c89.png)

#### 구현된 테스트
- 회원가입 성공
- 이미 존재하는 이메일 일 때
- 로그인 성공



TO-BE
-----
- [ ] 이메일 인증
- [ ] 상품 데이터 크롤링 및 저장 구현 중
- [ ] 상품, 가격, 브랜드 별 CRUD

테스트 
-----
- [ ] 테스트 코드
- [ ] API 테스트 