### PR TITLE
금일 인기 상품 조회 api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     // querydsl 디펜던시 추가
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
     implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
+    implementation "com.querydsl:querydsl-core:${queryDslVersion}"
 
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/src/main/java/com/zerobase/musinsamonitor/MusinsaMonitorApplication.java
+++ b/src/main/java/com/zerobase/musinsamonitor/MusinsaMonitorApplication.java
@@ -5,22 +5,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
-@EnableCaching
 public class MusinsaMonitorApplication {
-
-    //    private static final int[] pages = {1, 11, 21, 31, 41, 51, 61, 71, 81, 91};
-    private static final int[] pages = {1};
 
     public static void main(String[] args) {
         SpringApplication.run(MusinsaMonitorApplication.class, args);
-
-//        Crawler crawler = new MusinsaCrawler();
-//
-//        CrawledResult result = crawler.crawling();
-//
-//        System.out.println(result);
-//        System.out.println(Category.numToString());
-
-
     }
 }

--- a/src/main/java/com/zerobase/musinsamonitor/config/RedisConfig.java
+++ b/src/main/java/com/zerobase/musinsamonitor/config/RedisConfig.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
@@ -17,6 +18,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @RequiredArgsConstructor
+@EnableCaching
 public class RedisConfig {
 
     @Value("${spring.redis.host}")

--- a/src/main/java/com/zerobase/musinsamonitor/controller/AuthController.java
+++ b/src/main/java/com/zerobase/musinsamonitor/controller/AuthController.java
@@ -23,8 +23,6 @@ public class AuthController {
 
     private final MemberService memberService;
 
-    private final TokenProvider tokenProvider;
-
     /**
      * 회원가입을 위한 API
      */

--- a/src/main/java/com/zerobase/musinsamonitor/controller/ProductController.java
+++ b/src/main/java/com/zerobase/musinsamonitor/controller/ProductController.java
@@ -2,15 +2,14 @@ package com.zerobase.musinsamonitor.controller;
 
 import com.zerobase.musinsamonitor.crawler.Crawler;
 import com.zerobase.musinsamonitor.crawler.MusinsaCrawler;
+import com.zerobase.musinsamonitor.crawler.constants.Category;
 import com.zerobase.musinsamonitor.crawler.dto.CrawledResult;
 import com.zerobase.musinsamonitor.dto.ProductResponseDto;
 import com.zerobase.musinsamonitor.service.CrawlingService;
 import com.zerobase.musinsamonitor.service.ProductService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,8 +27,19 @@ public class ProductController {
 
 
     @GetMapping("/product/brand")
-    public ResponseEntity<Page<ProductResponseDto>> findProductsByBrand(@RequestParam String brandName, Pageable pageable) {
+    public ResponseEntity<Page<ProductResponseDto>> findProductsByBrand(@RequestParam String brandName,
+        Pageable pageable) {
         Page<ProductResponseDto> results = productService.findProductsByBrand(brandName, pageable);
+        return ResponseEntity.ok(results);
+    }
+
+    @GetMapping("/product/best")
+    public ResponseEntity<Page<ProductResponseDto>> findTodayProductsByCategory(@RequestParam Category category
+        , @RequestParam String period
+        , Pageable pageable
+    ) {
+        Page<ProductResponseDto> results = productService.findTodayProductsByCategory(category, period,
+            pageable);
         return ResponseEntity.ok(results);
     }
 

--- a/src/main/java/com/zerobase/musinsamonitor/controller/ProductController.java
+++ b/src/main/java/com/zerobase/musinsamonitor/controller/ProductController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,12 +19,12 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api")
-@RequiredArgsConstructor
 @RestController
+@RequiredArgsConstructor
 public class ProductController {
 
     private final ProductService productService;
-    private final CrawlingService crawlingService;
+//    private final CrawlingService crawlingService;
 
 
     @GetMapping("/product/brand")
@@ -33,6 +34,7 @@ public class ProductController {
         return ResponseEntity.ok(results);
     }
 
+//    @Secured({"ROLE_ADMIN"})
     @GetMapping("/product/best")
     public ResponseEntity<Page<ProductResponseDto>> findTodayProductsByCategory(@RequestParam Category category
         , @RequestParam String period
@@ -43,10 +45,10 @@ public class ProductController {
         return ResponseEntity.ok(results);
     }
 
-    @PostMapping("/product/save")
-    public void saveCrawlingDate() {
-        Crawler crawler = new MusinsaCrawler();
-        CrawledResult crawledResult = crawler.crawling();
-        crawlingService.save(crawledResult);
-    }
+//    @PostMapping("/product/save")
+//    public void saveCrawlingDate() {
+//        Crawler crawler = new MusinsaCrawler();
+//        CrawledResult crawledResult = crawler.crawling();
+//        crawlingService.save(crawledResult);
+//    }
 }

--- a/src/main/java/com/zerobase/musinsamonitor/crawler/MusinsaCrawler.java
+++ b/src/main/java/com/zerobase/musinsamonitor/crawler/MusinsaCrawler.java
@@ -26,8 +26,9 @@ public class MusinsaCrawler implements Crawler {
         List<ProductDto> productList = new ArrayList<>();
         List<PriceDto> priceList = new ArrayList<>();
 
-        for (String category : Category.numToString()) {
+        for (String category : Category.getCategoryList()) {
             for (int page = START_PAGE; page <= END_PAGE; page++) {
+
                 try {
                     String url = String.format(URL, category, page);
 

--- a/src/main/java/com/zerobase/musinsamonitor/crawler/constants/Category.java
+++ b/src/main/java/com/zerobase/musinsamonitor/crawler/constants/Category.java
@@ -15,12 +15,17 @@ public enum Category {
 //    SOCKS(8), // 양말/레그웨어 008
 //    SUNGLASSES(9); // 선글라스/안경테 009
 
-    TOP(1);
+    TOP("001");
 
-    private int number;
+    private String category;
+    private int num;
 
-    Category(int n) {
-        this.number = n;
+    Category(String category) {
+        this.category = category;
+    }
+
+    public String getCategory(){
+        return this.category;
     }
 
     /**
@@ -28,9 +33,9 @@ public enum Category {
      *
      * @return "001"
      */
-    public static List<String> numToString() {
+    public static List<String> getCategoryList() {
         return Arrays.stream(Category.values())
-            .map(e -> String.format("%03d", e.number))
+            .map(Category::getCategory)
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/zerobase/musinsamonitor/dto/ProductResponseDto.java
+++ b/src/main/java/com/zerobase/musinsamonitor/dto/ProductResponseDto.java
@@ -15,7 +15,7 @@ public class ProductResponseDto {
     private final String productUrl;
     private final String brand;
     private final String brandUrl;
-    private final LocalDate modifiedDate;
+    private final LocalDate updatedAt;
     private final String category;
     private final int price;
 
@@ -28,7 +28,7 @@ public class ProductResponseDto {
         this.productUrl = product.getProductUrl();
         this.brand = product.getBrand();
         this.brandUrl = product.getBrandUrl();
-        this.modifiedDate = product.getUpdatedAt().toLocalDate();
+        this.updatedAt = product.getUpdatedAt().toLocalDate();
         this.category = product.getCategory();
         this.price = product.getPrice();
     }

--- a/src/main/java/com/zerobase/musinsamonitor/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/musinsamonitor/exception/ErrorCode.java
@@ -15,6 +15,8 @@ public enum ErrorCode {
     EMAIL_ALREADY_USED(BAD_REQUEST,"이미 사용 중인 이메일입니다."),
     EMAIL_NOT_FOUND(BAD_REQUEST, "존재하지 않는 Email 입니다."),
     PASSWORD_DO_NOT_MATCH(BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    NON_EXISTENT_BRAND(BAD_REQUEST, "존재하지 않는 브랜드입니다."),
+    DO_NOT_SUPPORTED_CATEGORY(BAD_REQUEST,"지원하지 않는 카테고리입니다."),
     /* 401 UNAUTHORIZED : 인증되지 않은 사용자 */
 
     /* 404 NOT_FOUND : Resource 를 찾을 수 없음 */

--- a/src/main/java/com/zerobase/musinsamonitor/repository/ProductQueryRepository.java
+++ b/src/main/java/com/zerobase/musinsamonitor/repository/ProductQueryRepository.java
@@ -1,6 +1,6 @@
 package com.zerobase.musinsamonitor.repository;
 
-import static com.zerobase.musinsamonitor.repository.entiry.QProduct.product;
+import static com.zerobase.musinsamonitor.repository.entity.QProduct.product;
 
 import com.querydsl.core.types.ConstantImpl;
 import com.querydsl.core.types.dsl.Expressions;
@@ -9,7 +9,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.zerobase.musinsamonitor.crawler.constants.Category;
 import com.zerobase.musinsamonitor.dto.ProductResponseDto;
 import com.zerobase.musinsamonitor.repository.entity.Product;
-import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/com/zerobase/musinsamonitor/repository/ProductQueryRepository.java
+++ b/src/main/java/com/zerobase/musinsamonitor/repository/ProductQueryRepository.java
@@ -2,9 +2,15 @@ package com.zerobase.musinsamonitor.repository;
 
 import static com.zerobase.musinsamonitor.repository.entiry.QProduct.product;
 
+import com.querydsl.core.types.ConstantImpl;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringTemplate;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zerobase.musinsamonitor.crawler.constants.Category;
 import com.zerobase.musinsamonitor.dto.ProductResponseDto;
 import com.zerobase.musinsamonitor.repository.entity.Product;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.persistence.EntityManager;
@@ -25,12 +31,42 @@ public class ProductQueryRepository {
     public Page<ProductResponseDto> findByBrand(String brandName, Pageable pageable) {
         List<Product> productList = jpaQueryFactory.selectFrom(product)
             .where(product.brand.eq(brandName))
-            .orderBy(product.updatedAt.desc())
+            .orderBy( product.ranking.asc(), product.updatedAt.desc())
             .limit(pageable.getPageSize())
             .offset(pageable.getOffset())
             .fetch();
 
         // List ->  Page
+        return new PageImpl<>(productList.stream()
+            .map(ProductResponseDto::new)
+            .collect(Collectors.toList())
+            , pageable
+            , productList.size()
+        );
+    }
+
+    public Page<ProductResponseDto> findTodayProductByCategory(Category category, String period, Pageable pageable) {
+        StringTemplate formattedDate = Expressions.stringTemplate(
+          "DATE_FORMAT({0}, {1})"
+            , product.updatedAt
+            , ConstantImpl.create("%Y-%m-%d")
+        );
+
+        StringTemplate now = Expressions.stringTemplate(
+            "DATE_FORMAT({0}, {1})"
+            , LocalDateTime.now()
+            , ConstantImpl.create("%Y-%m-%d")
+        );
+
+        List<Product> productList = jpaQueryFactory.selectFrom(product)
+            .where(formattedDate.eq(now)
+                , product.category.eq(category.getCategory())
+            )
+            .orderBy(product.ranking.asc())
+            .limit(pageable.getPageSize())
+            .offset(pageable.getOffset())
+            .fetch();
+
         return new PageImpl<>(productList.stream()
             .map(ProductResponseDto::new)
             .collect(Collectors.toList())

--- a/src/main/java/com/zerobase/musinsamonitor/repository/entity/Product.java
+++ b/src/main/java/com/zerobase/musinsamonitor/repository/entity/Product.java
@@ -23,8 +23,8 @@ import org.hibernate.annotations.DynamicUpdate;
 @DynamicUpdate
 public class Product implements Serializable {
 
-    @Column(name = "product_id")
     @Id
+    @Column(name = "product_id")
     private int productId;
 
     private String productName;

--- a/src/main/java/com/zerobase/musinsamonitor/repository/entity/Product.java
+++ b/src/main/java/com/zerobase/musinsamonitor/repository/entity/Product.java
@@ -23,16 +23,9 @@ import org.hibernate.annotations.DynamicUpdate;
 @DynamicUpdate
 public class Product implements Serializable {
 
-//    @Id
-//    @GeneratedValue(strategy = GenerationType.IDENTITY)
-//    private Long id;
-
     @Column(name = "product_id")
     @Id
     private int productId;
-
-//    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL)
-//    List<Price> prices = new ArrayList<>();
 
     private String productName;
 
@@ -59,7 +52,6 @@ public class Product implements Serializable {
     private int ratingCount;
 
     private LocalDateTime updatedAt;
-
 
 
     @Builder

--- a/src/main/java/com/zerobase/musinsamonitor/security/SecurityConfiguration.java
+++ b/src/main/java/com/zerobase/musinsamonitor/security/SecurityConfiguration.java
@@ -40,7 +40,8 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS) // jwt 토큰으로 구현했기 때문에 상태 정보 저장X
             .and()
             .authorizeRequests()
-            .antMatchers("/**/signup", "/**/signin").permitAll()
+            // TODO : api 구현 후 권한 지정하기
+            .antMatchers("/**/sign-up", "/**/sign-in", "/**/**").permitAll()
             .and()
             .addFilterBefore(this.jwtAuthenticationFilter,
                 UsernamePasswordAuthenticationFilter.class); // 필터 순서 정의

--- a/src/main/java/com/zerobase/musinsamonitor/security/SecurityConfiguration.java
+++ b/src/main/java/com/zerobase/musinsamonitor/security/SecurityConfiguration.java
@@ -1,6 +1,7 @@
 package com.zerobase.musinsamonitor.security;
 
 import com.zerobase.musinsamonitor.security.jwt.JwtAuthenticationFilter;
+import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/zerobase/musinsamonitor/service/MemberDetailService.java
+++ b/src/main/java/com/zerobase/musinsamonitor/service/MemberDetailService.java
@@ -19,7 +19,6 @@ public class MemberDetailService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         return this.memberRepository.findByEmail(email)
-//            .orElseThrow(() -> new UsernameNotFoundException("couldn't find user -> " + email));
             .orElseThrow(() -> new CustomException(EMAIL_NOT_FOUND));
     }
 }

--- a/src/main/java/com/zerobase/musinsamonitor/service/ProductService.java
+++ b/src/main/java/com/zerobase/musinsamonitor/service/ProductService.java
@@ -1,5 +1,6 @@
 package com.zerobase.musinsamonitor.service;
 
+import com.zerobase.musinsamonitor.crawler.constants.Category;
 import com.zerobase.musinsamonitor.dto.ProductResponseDto;
 import com.zerobase.musinsamonitor.repository.ProductJpaRepository;
 import com.zerobase.musinsamonitor.repository.ProductQueryRepository;
@@ -24,5 +25,9 @@ public class ProductService {
         }
 
         return this.productQueryRepository.findByBrand(brandName, pageable);
+    }
+
+    public Page<ProductResponseDto> findTodayProductsByCategory(Category category, String period, Pageable pageable) {
+        return productQueryRepository.findTodayProductByCategory(category, period, pageable);
     }
 }

--- a/src/main/java/com/zerobase/musinsamonitor/service/ProductService.java
+++ b/src/main/java/com/zerobase/musinsamonitor/service/ProductService.java
@@ -1,7 +1,11 @@
 package com.zerobase.musinsamonitor.service;
 
+import static com.zerobase.musinsamonitor.exception.ErrorCode.DO_NOT_SUPPORTED_CATEGORY;
+import static com.zerobase.musinsamonitor.exception.ErrorCode.NON_EXISTENT_BRAND;
+
 import com.zerobase.musinsamonitor.crawler.constants.Category;
 import com.zerobase.musinsamonitor.dto.ProductResponseDto;
+import com.zerobase.musinsamonitor.exception.CustomException;
 import com.zerobase.musinsamonitor.repository.ProductJpaRepository;
 import com.zerobase.musinsamonitor.repository.ProductQueryRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,13 +25,16 @@ public class ProductService {
     public Page<ProductResponseDto> findProductsByBrand(String brandName, Pageable pageable) {
         boolean exists = productJpaRepository.existsByBrand(brandName);
         if (!exists) {
-            throw new RuntimeException("존재하지 않는 브랜드입니다.");
+            throw new CustomException(NON_EXISTENT_BRAND);
         }
 
         return this.productQueryRepository.findByBrand(brandName, pageable);
     }
 
     public Page<ProductResponseDto> findTodayProductsByCategory(Category category, String period, Pageable pageable) {
+        if(!Category.getCategoryList().contains(category.getCategory())){
+            throw new CustomException(DO_NOT_SUPPORTED_CATEGORY);
+        }
         return productQueryRepository.findTodayProductByCategory(category, period, pageable);
     }
 }

--- a/src/main/java/com/zerobase/musinsamonitor/service/ProductService.java
+++ b/src/main/java/com/zerobase/musinsamonitor/service/ProductService.java
@@ -10,7 +10,6 @@ import com.zerobase.musinsamonitor.repository.ProductJpaRepository;
 import com.zerobase.musinsamonitor.repository.ProductQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 


### PR DESCRIPTION
변경사항
-----
- #7 

**AS-IS**
금일 인기 상품 조회 API
- @RequestParam 날짜 기간, 카테고리 요청 시 금일 인기 상품 리스트를 랭킹 순으로 반환합니다.
- JPA를 이용 시 필터링 작업에 메소드 명이 길어지면서 가독성이 안 좋아서져서 Querydsl을 이용하였습니다.

**TO-BE**
- [ ]  상품 상세 
- [ ]  가격
- [ ]  금일 최저 가격
- [ ]  할인 상품
- [ ]  브랜드 리스트

