### PR TITLE
[feat] 금일 할인 상품 조회 API

### DIFF
--- a/src/main/java/com/zerobase/musinsamonitor/controller/DiscountedProductController.java
+++ b/src/main/java/com/zerobase/musinsamonitor/controller/DiscountedProductController.java
@@ -1,0 +1,24 @@
+package com.zerobase.musinsamonitor.controller;
+
+
+import com.zerobase.musinsamonitor.dto.ProductAndDiscountResponseDto;
+import com.zerobase.musinsamonitor.service.DiscountedProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api")
+@RestController
+@RequiredArgsConstructor
+public class DiscountedProductController {
+
+    private final DiscountedProductService discountedProductService;
+
+    @GetMapping("/product/discount/today-list")
+    public Page<ProductAndDiscountResponseDto> findTodayDiscountedProducts(Pageable pageable) {
+        return discountedProductService.findTodayDiscountedProducts(pageable);
+    }
+}

--- a/src/main/java/com/zerobase/musinsamonitor/crawler/MusinsaCrawler.java
+++ b/src/main/java/com/zerobase/musinsamonitor/crawler/MusinsaCrawler.java
@@ -96,6 +96,7 @@ public class MusinsaCrawler implements Crawler {
                             .ranking(ranking)
                             .category(category)
                             .price(price)
+                            .coupon(coupon)
                             .rating(rating)
                             .ratingCount(ratingCount)
                             .build();

--- a/src/main/java/com/zerobase/musinsamonitor/crawler/dto/ProductDto.java
+++ b/src/main/java/com/zerobase/musinsamonitor/crawler/dto/ProductDto.java
@@ -27,6 +27,8 @@ public class ProductDto {
 
     private int price;
 
+    private int coupon;
+
     private float rating;
 
     private int ratingCount;

--- a/src/main/java/com/zerobase/musinsamonitor/dto/ProductAndDiscountResponseDto.java
+++ b/src/main/java/com/zerobase/musinsamonitor/dto/ProductAndDiscountResponseDto.java
@@ -1,0 +1,43 @@
+package com.zerobase.musinsamonitor.dto;
+
+import com.zerobase.musinsamonitor.repository.entity.Product;
+import com.zerobase.musinsamonitor.repository.entity.TodayDiscountedProduct;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ProductAndDiscountResponseDto {
+
+    private final String category;
+    private final int productId;
+    private final String productName;
+    private final String productUrl;
+    private final String brand;
+    private final String brandUrl;
+    private final int ranking;
+    private final String img;
+    private final int price;
+    private final int discountPrice;
+    private final double discountRate;
+    private final LocalDateTime createdAt;
+
+
+
+    @Builder
+    public ProductAndDiscountResponseDto(TodayDiscountedProduct entity) {
+        this.category = entity.getProduct().getCategory();
+        this.productId = entity.getProduct().getProductId();
+        this.productName = entity.getProduct().getProductName();
+        this.productUrl = entity.getProduct().getProductUrl();
+        this.brand = entity.getProduct().getBrand();
+        this.brandUrl = entity.getProduct().getBrandUrl();
+        this.ranking = entity.getProduct().getRanking();
+        this.img = entity.getProduct().getImg();
+        this.price = entity.getProduct().getPrice();
+        this.discountPrice = entity.getDiscountPrice();
+        this.discountRate = entity.getDiscountRate();
+        this.createdAt = entity.getCreatedAt();
+    }
+
+}

--- a/src/main/java/com/zerobase/musinsamonitor/repository/TodayDiscountedProductQueryRepository.java
+++ b/src/main/java/com/zerobase/musinsamonitor/repository/TodayDiscountedProductQueryRepository.java
@@ -1,0 +1,65 @@
+package com.zerobase.musinsamonitor.repository;
+
+import static com.zerobase.musinsamonitor.repository.entity.QProduct.product;
+import static com.zerobase.musinsamonitor.repository.entity.QTodayDiscountedProduct.todayDiscountedProduct;
+
+import com.querydsl.core.types.ConstantImpl;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringTemplate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zerobase.musinsamonitor.dto.ProductAndDiscountResponseDto;
+import com.zerobase.musinsamonitor.repository.entity.TodayDiscountedProduct;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class TodayDiscountedProductQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    /**
+     * select count(*)
+     * from discount
+     * 	inner join product
+     *     on discount.product_id = product.product_id
+     *     where discount.created_at >= curdate()
+     * order by product.ranking asc;
+     */
+    public Page<ProductAndDiscountResponseDto> findTodayDiscountedProducts(Pageable pageable) {
+        StringTemplate formattedDate = Expressions.stringTemplate(
+            "DATE_FORMAT({0}, {1})"
+            , todayDiscountedProduct.createdAt
+            , ConstantImpl.create("%Y-%m-%d")
+        );
+
+        StringTemplate now = Expressions.stringTemplate(
+            "DATE_FORMAT({0}, {1})"
+            , LocalDateTime.now()
+            , ConstantImpl.create("%Y-%m-%d")
+        );
+
+        List<TodayDiscountedProduct> discountedProductList = jpaQueryFactory.selectFrom(todayDiscountedProduct)
+            .innerJoin(todayDiscountedProduct.product)
+            .where(
+                formattedDate.eq(now)
+            )
+            .orderBy(todayDiscountedProduct.product.ranking.asc())
+            .limit(pageable.getPageSize())
+            .offset(pageable.getOffset())
+            .fetch();
+
+        return new PageImpl<>(discountedProductList.stream()
+            .map(ProductAndDiscountResponseDto::new)
+            .collect(Collectors.toList())
+            , pageable
+            , discountedProductList.size()
+        );
+    }
+}

--- a/src/main/java/com/zerobase/musinsamonitor/repository/TodayDiscountedProductRepository.java
+++ b/src/main/java/com/zerobase/musinsamonitor/repository/TodayDiscountedProductRepository.java
@@ -1,0 +1,10 @@
+package com.zerobase.musinsamonitor.repository;
+
+import com.zerobase.musinsamonitor.repository.entity.TodayDiscountedProduct;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TodayDiscountedProductRepository extends JpaRepository<TodayDiscountedProduct, Integer> {
+
+}

--- a/src/main/java/com/zerobase/musinsamonitor/repository/entity/Price.java
+++ b/src/main/java/com/zerobase/musinsamonitor/repository/entity/Price.java
@@ -26,11 +26,6 @@ public class Price {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // https://bcp0109.tistory.com/344 - 상품 저장 전에 fk없이 가격을 저장하려고 해서 오류
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "product_id", referencedColumnName = "product_id")
-//    private Product product;
-
     private int productId;
 
     @Column(columnDefinition = "SMALLINT")

--- a/src/main/java/com/zerobase/musinsamonitor/repository/entity/Product.java
+++ b/src/main/java/com/zerobase/musinsamonitor/repository/entity/Product.java
@@ -47,6 +47,8 @@ public class Product implements Serializable {
 
     private int price;
 
+    private int coupon;
+
     private float rating;
 
     private int ratingCount;
@@ -66,6 +68,7 @@ public class Product implements Serializable {
         this.ranking = productDto.getRanking();
         this.category = productDto.getCategory();
         this.price = productDto.getPrice();
+        this.coupon = productDto.getCoupon();
         this.rating = productDto.getRating();
         this.ratingCount = productDto.getRatingCount();
         this.updatedAt = LocalDateTime.now();

--- a/src/main/java/com/zerobase/musinsamonitor/repository/entity/TodayDiscountedProduct.java
+++ b/src/main/java/com/zerobase/musinsamonitor/repository/entity/TodayDiscountedProduct.java
@@ -1,0 +1,46 @@
+package com.zerobase.musinsamonitor.repository.entity;
+
+import java.time.LocalDateTime;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity(name = "DISCOUNT")
+@Getter
+@NoArgsConstructor
+@DynamicUpdate
+@ToString
+public class TodayDiscountedProduct {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, name = "product_id", referencedColumnName = "product_id")
+    private Product product;
+
+    private int discountPrice;
+
+    private double discountRate;
+
+    private LocalDateTime createdAt;
+
+    @Builder
+    public TodayDiscountedProduct(Product product, int discountPrice, double discountRate, LocalDateTime createdAt ) {
+        this.product = product;
+        this.discountPrice = discountPrice;
+        this.discountRate = discountRate;
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/zerobase/musinsamonitor/service/CrawlingService.java
+++ b/src/main/java/com/zerobase/musinsamonitor/service/CrawlingService.java
@@ -4,21 +4,27 @@ import com.zerobase.musinsamonitor.crawler.dto.CrawledResult;
 import com.zerobase.musinsamonitor.repository.PriceRepository;
 import com.zerobase.musinsamonitor.repository.ProductJpaRepository;
 import com.zerobase.musinsamonitor.repository.ProductQueryRepository;
+import com.zerobase.musinsamonitor.repository.TodayDiscountedProductRepository;
 import com.zerobase.musinsamonitor.repository.entity.Price;
 import com.zerobase.musinsamonitor.repository.entity.Product;
+import com.zerobase.musinsamonitor.repository.entity.TodayDiscountedProduct;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.util.ObjectUtils;
 
 @RequiredArgsConstructor
 @Service
 public class CrawlingService {
 
     private final ProductJpaRepository productJpaRepository;
-    private final ProductQueryRepository productQueryRepository;
 
     private final PriceRepository priceRepository;
+
+    private final TodayDiscountedProductRepository todayDiscountedProductRepository;
 
     public void save(CrawledResult crawledResult) {
 
@@ -27,12 +33,26 @@ public class CrawlingService {
             .map(Product::new)
             .collect(Collectors.toList());
 
-        this.productJpaRepository.saveAll(productEntities);
+        List<Product> products = this.productJpaRepository.saveAll(productEntities);
 
         List<Price> priceEntities = crawledResult.getPrices().stream()
             .map(Price::new)
             .collect(Collectors.toList());
 
-        this.priceRepository.saveAll(priceEntities);
+        List<Price> prices = this.priceRepository.saveAll(priceEntities);
+
+        if (!ObjectUtils.isEmpty(products)) {
+
+            List<TodayDiscountedProduct> todayDiscountedProducts = products.stream()
+                .filter(e -> e.getCoupon() > 0)
+                .map(e -> new TodayDiscountedProduct(
+                    e
+                    , e.getPrice() - e.getCoupon()
+                    , (int) ((double) e.getCoupon() / e.getPrice() * 100)
+                    , e.getUpdatedAt()
+                )).collect(Collectors.toList());
+
+            this.todayDiscountedProductRepository.saveAll(todayDiscountedProducts);
+        }
     }
 }

--- a/src/main/java/com/zerobase/musinsamonitor/service/DiscountedProductService.java
+++ b/src/main/java/com/zerobase/musinsamonitor/service/DiscountedProductService.java
@@ -1,0 +1,21 @@
+package com.zerobase.musinsamonitor.service;
+
+import com.zerobase.musinsamonitor.dto.ProductAndDiscountResponseDto;
+import com.zerobase.musinsamonitor.repository.TodayDiscountedProductQueryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DiscountedProductService {
+
+    private final TodayDiscountedProductQueryRepository todayDiscountedProductQueryRepository;
+
+    public Page<ProductAndDiscountResponseDto> findTodayDiscountedProducts(Pageable pageable) {
+        return todayDiscountedProductQueryRepository.findTodayDiscountedProducts(pageable);
+    }
+}


### PR DESCRIPTION
### 변경사항
- #7  

AS-IS
-----
**금일 할인 상품 조회 API**

- API 요청 시 금일 할인(쿠폰이 적용된) 상품을 랭킹 순으로 반환합니다.

![image](https://user-images.githubusercontent.com/53173850/212886075-0778cc42-894b-4591-b00a-8af146f9061f.png)

- JPA를 이용 시 필터링 작업에 메소드 명이 길어지면서 가독성이 안 좋아져서 Querydsl을 이용하였습니다.

**Crawling Result 수정**
- 상품 : 할인 테이블의 1:1 연관관계를 위해 기존 상품 테이블에 없던 coupon 컬럼을 추가하였습니다.
- coupon 컬럼이 추가됨에 따라 상품 데이터에서 할인율, 할인 금액을 계산 가능합니다.
- 상품, 할인 테이블의 연관 관계로 인해 productId를 기반으로 할인 데이터 조회 시 상품 연관된 상품 데이터도 같이 조회됩니다.




TO-BE
-----

- [x]  가격
- [ ]  금일 최저 가격
- [ ]  브랜드 리스트
